### PR TITLE
[Sync] Update project files from source repository (31ecff7)

### DIFF
--- a/.github/CODE_STANDARDS.md
+++ b/.github/CODE_STANDARDS.md
@@ -45,7 +45,6 @@ When in doubt, check the official docs:
 * 📃 [godoc](https://pkg.go.dev/golang.org/x/tools/cmd/godoc)
 * 🔧 [gofmt](https://golang.org/cmd/gofmt/)
 * 📊 [golangci-lint](https://golangci-lint.run/)
-* 📈 [Go Report Card](https://goreportcard.com/)
 
 <br/>
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,7 +42,6 @@ We follow [Effective Go](https://golang.org/doc/effective_go.html), plus:
 
 * 📖 [godoc](https://godoc.org/golang.org/x/tools/cmd/godoc)
 * 🧼 [golangci-lint](https://golangci-lint.run/)
-* 🧾 [Go Report Card](https://goreportcard.com/)
 
 Format your code with `gofmt`, lint with `golangci-lint`, and keep your diffs minimal.
 

--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.24.1
+MAGE_X_VERSION=v1.25.0
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false
@@ -70,9 +70,9 @@ MAGE_X_FORMAT_EXCLUDE_PATHS=vendor,node_modules,.git,.idea
 # ================================================================================================
 
 MAGE_X_GITLEAKS_VERSION=8.30.1
-MAGE_X_GOFUMPT_VERSION=v0.10.0
+MAGE_X_GOFUMPT_VERSION=v0.11.0
 MAGE_X_GOLANGCI_LINT_VERSION=v2.12.2
-MAGE_X_GORELEASER_VERSION=v2.17.0
+MAGE_X_GORELEASER_VERSION=v2.17.1
 MAGE_X_GOVULNCHECK_VERSION=v1.1.4
 MAGE_X_GO_SECONDARY_VERSION=1.24.x
 MAGE_X_GO_VERSION=1.24.x

--- a/.github/env/10-pre-commit.env
+++ b/.github/env/10-pre-commit.env
@@ -53,7 +53,7 @@ GO_PRE_COMMIT_ALL_FILES=true
 # ================================================================================================
 
 GO_PRE_COMMIT_GOLANGCI_LINT_VERSION=v2.12.2
-GO_PRE_COMMIT_FUMPT_VERSION=v0.10.0
+GO_PRE_COMMIT_FUMPT_VERSION=v0.11.0
 GO_PRE_COMMIT_GOIMPORTS_VERSION=latest
 GO_PRE_COMMIT_GITLEAKS_VERSION=v8.30.1
 


### PR DESCRIPTION
## What Changed

* Removed "Go Report Card" references from documentation in `.github/CODE_STANDARDS.md` and `.github/CONTRIBUTING.md`
* Updated `MAGE_X_VERSION` from `v1.24.1` to `v1.25.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_GOFUMPT_VERSION` from `v0.10.0` to `v0.11.0` in `.github/env/10-mage-x.env`
* Updated `MAGE_X_GORELEASER_VERSION` from `v2.17.0` to `v2.17.1` in `.github/env/10-mage-x.env`
* Updated `GO_PRE_COMMIT_FUMPT_VERSION` from `v0.10.0` to `v0.11.0` in `.github/env/10-pre-commit.env`

## Why It Was Necessary

* Go Report Card references were removed from developer documentation to streamline tooling recommendations
* Mage-X framework update to v1.25.0 provides latest build system capabilities and improvements
* Gofumpt and GoReleaser updates ensure developers use current versions with bug fixes and enhancements
* Keeping pre-commit hook versions synchronized with mage-x environment maintains consistency across development workflows

## Testing Performed

* Verified environment configuration files contain valid version strings and proper formatting
* Confirmed documentation changes remove only Go Report Card references without affecting other tool listings
* Validated that version updates align with available releases of respective tools
* Checked that mage-x and pre-commit configurations remain internally consistent

## Impact / Risk

* **Low Risk**: Version updates are incremental and documentation changes are non-functional
* **No Breaking Changes**: Tooling updates maintain backward compatibility with existing workflows
* **Developer Experience**: Developers may need to update local tool installations to match new versions
* **CI/CD**: Automated builds will use updated tool versions on next execution

<!-- go-broadcast-metadata
group:
  id: mrz-tools
  name: mrz-tools
diff_info:
  staged_repo_available: true
  changed_files_count: 4
  files_with_original_content: 4
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 31ecff74272ac87c2e6ed4bfe911cea832a98edb
  target_repo: mrz1836/go-fortress
  sync_commit: c2ceaa0966e9a56d4e045b6ed4df8ecdca3e9a45
  sync_time: 2026-07-28T12:27:35-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 266
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 861
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 542
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 2
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 588
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 499
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1157
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 1426
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 359
performance:
  total_files: 103
-->
